### PR TITLE
feat: SQLite database schema and migrations

### DIFF
--- a/src/db/schema.test.ts
+++ b/src/db/schema.test.ts
@@ -1,0 +1,96 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runMigrations } from "./schema";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe("runMigrations", () => {
+  it("creates all tables on first run", () => {
+    runMigrations(db);
+
+    const tables = (
+      db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as {
+        name: string;
+      }[]
+    ).map((r) => r.name);
+
+    expect(tables).toContain("feeds");
+    expect(tables).toContain("articles");
+    expect(tables).toContain("tags");
+    expect(tables).toContain("article_tags");
+    expect(tables).toContain("migrations");
+  });
+
+  it("creates the FTS5 virtual table", () => {
+    runMigrations(db);
+
+    const vtable = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='articles_fts'")
+      .get();
+
+    expect(vtable).toBeTruthy();
+  });
+
+  it("records applied migration versions", () => {
+    runMigrations(db);
+
+    const versions = (
+      db.prepare("SELECT version FROM migrations").all() as { version: number }[]
+    ).map((r) => r.version);
+
+    expect(versions).toContain(1);
+  });
+
+  it("is idempotent — running twice does not error or duplicate", () => {
+    runMigrations(db);
+    expect(() => runMigrations(db)).not.toThrow();
+
+    const count = (db.prepare("SELECT COUNT(*) as c FROM migrations").get() as { c: number }).c;
+    expect(count).toBe(1);
+  });
+
+  it("FTS5 triggers keep the index in sync on insert", () => {
+    runMigrations(db);
+
+    db.prepare("INSERT INTO feeds (url, title) VALUES (?, ?)").run(
+      "https://example.com/feed",
+      "Test Feed",
+    );
+    db.prepare(
+      "INSERT INTO articles (feed_id, guid, title, content) VALUES (1, 'g1', 'Hello World', 'Some content here')",
+    ).run();
+
+    const results = db
+      .prepare("SELECT rowid FROM articles_fts WHERE articles_fts MATCH 'Hello'")
+      .all();
+    expect(results.length).toBe(1);
+  });
+
+  it("FTS5 triggers remove deleted articles from the index", () => {
+    runMigrations(db);
+
+    db.prepare("INSERT INTO feeds (url, title) VALUES (?, ?)").run(
+      "https://example.com/feed",
+      "Test Feed",
+    );
+    db.prepare(
+      "INSERT INTO articles (feed_id, guid, title, content) VALUES (1, 'g1', 'Goodbye World', 'Some content')",
+    ).run();
+
+    db.prepare("DELETE FROM articles WHERE guid = 'g1'").run();
+
+    const results = db
+      .prepare("SELECT rowid FROM articles_fts WHERE articles_fts MATCH 'Goodbye'")
+      .all();
+    expect(results.length).toBe(0);
+  });
+});

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,92 @@
+import type Database from "better-sqlite3";
+
+const MIGRATIONS: { version: number; sql: string }[] = [
+  {
+    version: 1,
+    sql: `
+      CREATE TABLE IF NOT EXISTS feeds (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        url           TEXT    NOT NULL UNIQUE,
+        title         TEXT    NOT NULL DEFAULT '',
+        description   TEXT    NOT NULL DEFAULT '',
+        site_url      TEXT    NOT NULL DEFAULT '',
+        category      TEXT    NOT NULL DEFAULT '',
+        created_at    INTEGER NOT NULL DEFAULT (unixepoch()),
+        last_fetched_at INTEGER
+      );
+
+      CREATE TABLE IF NOT EXISTS articles (
+        id           INTEGER PRIMARY KEY AUTOINCREMENT,
+        feed_id      INTEGER NOT NULL REFERENCES feeds(id) ON DELETE CASCADE,
+        guid         TEXT    NOT NULL,
+        title        TEXT    NOT NULL DEFAULT '',
+        link         TEXT    NOT NULL DEFAULT '',
+        content      TEXT    NOT NULL DEFAULT '',
+        summary      TEXT    NOT NULL DEFAULT '',
+        author       TEXT    NOT NULL DEFAULT '',
+        published_at INTEGER,
+        is_read      INTEGER NOT NULL DEFAULT 0,
+        is_starred   INTEGER NOT NULL DEFAULT 0,
+        created_at   INTEGER NOT NULL DEFAULT (unixepoch()),
+        UNIQUE(feed_id, guid)
+      );
+
+      CREATE TABLE IF NOT EXISTS tags (
+        id   INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL UNIQUE
+      );
+
+      CREATE TABLE IF NOT EXISTS article_tags (
+        article_id INTEGER NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+        tag_id     INTEGER NOT NULL REFERENCES tags(id)     ON DELETE CASCADE,
+        PRIMARY KEY (article_id, tag_id)
+      );
+
+      CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
+        title,
+        content,
+        content='articles',
+        content_rowid='id'
+      );
+
+      CREATE TRIGGER IF NOT EXISTS articles_fts_insert
+        AFTER INSERT ON articles BEGIN
+          INSERT INTO articles_fts(rowid, title, content)
+          VALUES (new.id, new.title, new.content);
+        END;
+
+      CREATE TRIGGER IF NOT EXISTS articles_fts_update
+        AFTER UPDATE ON articles BEGIN
+          INSERT INTO articles_fts(articles_fts, rowid, title, content)
+          VALUES ('delete', old.id, old.title, old.content);
+          INSERT INTO articles_fts(rowid, title, content)
+          VALUES (new.id, new.title, new.content);
+        END;
+
+      CREATE TRIGGER IF NOT EXISTS articles_fts_delete
+        BEFORE DELETE ON articles BEGIN
+          INSERT INTO articles_fts(articles_fts, rowid, title, content)
+          VALUES ('delete', old.id, old.title, old.content);
+        END;
+    `,
+  },
+];
+
+export function runMigrations(db: Database.Database): void {
+  db.exec("CREATE TABLE IF NOT EXISTS migrations (version INTEGER PRIMARY KEY)");
+
+  const applied = new Set<number>(
+    (db.prepare("SELECT version FROM migrations").all() as { version: number }[]).map(
+      (r) => r.version,
+    ),
+  );
+
+  for (const migration of MIGRATIONS) {
+    if (applied.has(migration.version)) continue;
+
+    db.transaction(() => {
+      db.exec(migration.sql);
+      db.prepare("INSERT INTO migrations (version) VALUES (?)").run(migration.version);
+    })();
+  }
+}


### PR DESCRIPTION
Closes #2

## Changes
- `src/db/schema.ts` — table definitions and `runMigrations()`
  - `feeds`, `articles`, `tags`, `article_tags` tables
  - FTS5 virtual table (`articles_fts`) with insert/update/delete triggers for automatic index sync
  - Version-based migration table tracks applied migrations
- `src/db/schema.test.ts` — 6 Vitest tests

## Verification
- `bun run test` ✅ (7 tests passing)
- `bun run lint` ✅