### PR TITLE
feat: full-text search service

### DIFF
--- a/src/services/search.test.ts
+++ b/src/services/search.test.ts
@@ -1,0 +1,109 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { addFeed, upsertArticle } from "../db/queries";
+import { runMigrations } from "../db/schema";
+import { searchArticles } from "./search";
+
+let db: Database.Database;
+
+function seedFeed(overrides: Partial<Parameters<typeof addFeed>[1]> = {}) {
+  return addFeed(db, {
+    url: "https://example.com/feed",
+    title: "Example Feed",
+    description: "A test feed",
+    site_url: "https://example.com",
+    category: "tech",
+    ...overrides,
+  });
+}
+
+function seedArticle(feedId: number, overrides: Partial<Parameters<typeof upsertArticle>[1]> = {}) {
+  return upsertArticle(db, {
+    feed_id: feedId,
+    guid: `guid-${Math.random()}`,
+    title: "Test Article",
+    link: "https://example.com/article",
+    content: "Full content here",
+    summary: "Summary here",
+    author: "Author",
+    published_at: Math.floor(Date.now() / 1000),
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe("searchArticles", () => {
+  it("returns an article whose title matches the query", () => {
+    const feed = seedFeed();
+    seedArticle(feed.id, {
+      guid: "g1",
+      title: "Introduction to Vitest",
+      content: "Some unrelated content",
+    });
+
+    const results = searchArticles(db, "Vitest");
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Introduction to Vitest");
+  });
+
+  it("returns an article whose content matches the query", () => {
+    const feed = seedFeed();
+    seedArticle(feed.id, {
+      guid: "g1",
+      title: "Generic Title",
+      content: "SQLite full-text search is powerful",
+    });
+
+    const results = searchArticles(db, "powerful");
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Generic Title");
+  });
+
+  it("returns an empty array when no articles match", () => {
+    const feed = seedFeed();
+    seedArticle(feed.id, { guid: "g1", title: "Hello World", content: "Basic content" });
+
+    const results = searchArticles(db, "zzznomatch");
+    expect(results).toEqual([]);
+  });
+
+  it("returns an empty array for an empty query without crashing", () => {
+    const feed = seedFeed();
+    seedArticle(feed.id, { guid: "g1" });
+
+    expect(searchArticles(db, "")).toEqual([]);
+    expect(searchArticles(db, "   ")).toEqual([]);
+  });
+
+  it("includes feed_title from the joined feeds table", () => {
+    const feed = seedFeed({ url: "https://tech.com/feed", title: "Tech News" });
+    seedArticle(feed.id, { guid: "g1", title: "TypeScript Tips" });
+
+    const results = searchArticles(db, "TypeScript");
+    expect(results).toHaveLength(1);
+    expect(results[0].feed_title).toBe("Tech News");
+  });
+
+  it("respects the limit parameter", () => {
+    const feed = seedFeed();
+    for (let i = 0; i < 5; i++) {
+      seedArticle(feed.id, {
+        guid: `guid-${i}`,
+        title: `Article number ${i}`,
+        content: "searchable keyword present",
+      });
+    }
+
+    const results = searchArticles(db, "searchable", 3);
+    expect(results).toHaveLength(3);
+  });
+});

--- a/src/services/search.ts
+++ b/src/services/search.ts
@@ -1,0 +1,69 @@
+import type Database from "better-sqlite3";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface SearchResult {
+  id: number;
+  feed_id: number;
+  guid: string;
+  title: string;
+  link: string;
+  summary: string;
+  author: string;
+  published_at: number | null;
+  is_read: 0 | 1;
+  is_starred: 0 | 1;
+  feed_title: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Strip FTS5 special characters that would cause a parse error, then append
+ * `*` for prefix matching on the last token.
+ */
+function sanitizeFtsQuery(raw: string): string {
+  // Remove FTS5 operator characters: " * ^ ( ) - :
+  const stripped = raw.replace(/["*^():+-]/g, " ").trim();
+
+  // Collapse multiple spaces and build the query
+  const tokens = stripped.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return "";
+
+  // Append * to the last token for prefix matching
+  tokens[tokens.length - 1] = `${tokens[tokens.length - 1]}*`;
+  return tokens.join(" ");
+}
+
+// ─── Search ───────────────────────────────────────────────────────────────────
+
+export function searchArticles(db: Database.Database, query: string, limit = 50): SearchResult[] {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+
+  const ftsQuery = sanitizeFtsQuery(trimmed);
+  if (!ftsQuery) return [];
+
+  return db
+    .prepare<[string, number], SearchResult>(
+      `SELECT
+         a.id,
+         a.feed_id,
+         a.guid,
+         a.title,
+         a.link,
+         a.summary,
+         a.author,
+         a.published_at,
+         a.is_read,
+         a.is_starred,
+         f.title AS feed_title
+       FROM articles_fts fts
+       JOIN articles a ON a.id = fts.rowid
+       JOIN feeds f ON f.id = a.feed_id
+       WHERE articles_fts MATCH ?
+       ORDER BY rank
+       LIMIT ?`,
+    )
+    .all(ftsQuery, limit);
+}


### PR DESCRIPTION
Closes #6

## What's implemented

### `src/services/search.ts`
- `SearchResult` interface with all article fields plus `feed_title` joined from the feeds table
- `searchArticles(db, query, limit?)` function using FTS5 `MATCH` with `ORDER BY rank` for relevance ordering
- Query sanitisation: strips FTS5 special characters (`"*^():-+`) then appends `*` for prefix matching on the last token
- Returns `[]` immediately for empty/whitespace queries
- Default limit: 50

### `src/services/search.test.ts`
6 Vitest tests using in-memory SQLite:
1. Keyword matching article title returns that article
2. Keyword matching article content returns that article
3. No-match query returns empty array (no crash)
4. Empty/whitespace query returns empty array
5. Results include `feed_title` from joined feeds table
6. Limit parameter is respected