### PR TITLE
feat: OPML import service

### DIFF
--- a/src/services/opml.test.ts
+++ b/src/services/opml.test.ts
@@ -1,0 +1,144 @@
+import { writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runMigrations } from "../db/schema";
+import { importOpml } from "./opml";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function writeTempOpml(content: string): Promise<string> {
+  const filePath = path.join(os.tmpdir(), `opml-test-${Date.now()}-${Math.random()}.opml`);
+  await writeFile(filePath, content, "utf-8");
+  return filePath;
+}
+
+const FLAT_OPML = `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>My Feeds</title></head>
+  <body>
+    <outline text="Hacker News" type="rss" xmlUrl="https://news.ycombinator.com/rss" />
+    <outline text="The Verge" type="rss" xmlUrl="https://www.theverge.com/rss/index.xml" />
+  </body>
+</opml>`;
+
+const CATEGORIZED_OPML = `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>My Feeds</title></head>
+  <body>
+    <outline text="Tech">
+      <outline text="Hacker News" type="rss" xmlUrl="https://news.ycombinator.com/rss" />
+      <outline text="The Verge" type="rss" xmlUrl="https://www.theverge.com/rss/index.xml" />
+    </outline>
+    <outline text="Science">
+      <outline text="NASA" type="rss" xmlUrl="https://www.nasa.gov/rss/dyn/breaking_news.rss" />
+    </outline>
+  </body>
+</opml>`;
+
+const NO_XMLURL_OPML = `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>My Feeds</title></head>
+  <body>
+    <outline text="Just a label, no xmlUrl" />
+    <outline text="Valid Feed" type="rss" xmlUrl="https://example.com/feed.xml" />
+  </body>
+</opml>`;
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("importOpml", () => {
+  it("adds all feeds from a flat OPML file", async () => {
+    const filePath = await writeTempOpml(FLAT_OPML);
+    const result = await importOpml(db, filePath);
+
+    expect(result.added).toBe(2);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+
+    const feeds = db.prepare("SELECT * FROM feeds ORDER BY url").all() as { url: string }[];
+    expect(feeds).toHaveLength(2);
+    expect(feeds.map((f) => f.url)).toContain("https://news.ycombinator.com/rss");
+    expect(feeds.map((f) => f.url)).toContain("https://www.theverge.com/rss/index.xml");
+  });
+
+  it("assigns correct category for feeds nested under a category outline", async () => {
+    const filePath = await writeTempOpml(CATEGORIZED_OPML);
+    const result = await importOpml(db, filePath);
+
+    expect(result.added).toBe(3);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+
+    const techFeeds = db
+      .prepare("SELECT * FROM feeds WHERE category = 'Tech' ORDER BY url")
+      .all() as { url: string; category: string }[];
+    expect(techFeeds).toHaveLength(2);
+
+    const scienceFeeds = db.prepare("SELECT * FROM feeds WHERE category = 'Science'").all() as {
+      url: string;
+      category: string;
+    }[];
+    expect(scienceFeeds).toHaveLength(1);
+    expect(scienceFeeds[0].url).toBe("https://www.nasa.gov/rss/dyn/breaking_news.rss");
+  });
+
+  it("counts feeds as skipped when re-importing the same OPML", async () => {
+    const filePath = await writeTempOpml(FLAT_OPML);
+
+    const firstImport = await importOpml(db, filePath);
+    expect(firstImport.added).toBe(2);
+    expect(firstImport.skipped).toBe(0);
+
+    const secondImport = await importOpml(db, filePath);
+    expect(secondImport.added).toBe(0);
+    expect(secondImport.skipped).toBe(2);
+    expect(secondImport.errors).toHaveLength(0);
+
+    // Still only 2 feeds in the DB
+    const count = (db.prepare("SELECT COUNT(*) as c FROM feeds").get() as { c: number }).c;
+    expect(count).toBe(2);
+  });
+
+  it("throws a clear error for a non-existent file", async () => {
+    await expect(importOpml(db, "/tmp/does-not-exist-opml-test.opml")).rejects.toThrow(
+      /Failed to read OPML file/,
+    );
+  });
+
+  it("throws a clear error for a file with no <opml> tag", async () => {
+    const filePath = await writeTempOpml("<html><body>Not OPML</body></html>");
+    await expect(importOpml(db, filePath)).rejects.toThrow(
+      /does not appear to be a valid OPML document/,
+    );
+  });
+
+  it("silently skips outline elements that are missing xmlUrl", async () => {
+    const filePath = await writeTempOpml(NO_XMLURL_OPML);
+    const result = await importOpml(db, filePath);
+
+    // Only the valid feed should be added; label-only outline is silently ignored
+    expect(result.added).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+
+    const feeds = db.prepare("SELECT * FROM feeds").all() as { url: string }[];
+    expect(feeds).toHaveLength(1);
+    expect(feeds[0].url).toBe("https://example.com/feed.xml");
+  });
+});

--- a/src/services/opml.ts
+++ b/src/services/opml.ts
@@ -1,0 +1,108 @@
+import { readFile } from "node:fs/promises";
+import type Database from "better-sqlite3";
+import { addFeed, getFeedByUrl } from "../db/queries";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ImportResult {
+  added: number;
+  skipped: number;
+  errors: string[];
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getAttribute(tag: string, name: string): string | null {
+  const re = new RegExp(`${name}=["']([^"']*)["']`, "i");
+  const m = re.exec(tag);
+  return m ? m[1] : null;
+}
+
+interface FeedEntry {
+  url: string;
+  title: string;
+  category: string;
+}
+
+function parseOpmlFeeds(xml: string): FeedEntry[] {
+  const results: FeedEntry[] = [];
+  const categoryStack: string[] = [];
+
+  // Match closing </outline> tags and opening/self-closing <outline ...> tags
+  const tokenRe = /(<\/outline>|<outline\b[^>]*\/?>)/gi;
+
+  for (;;) {
+    const match = tokenRe.exec(xml);
+    if (match === null) break;
+    const token = match[1];
+
+    if (/^<\/outline>/i.test(token)) {
+      categoryStack.pop();
+      continue;
+    }
+
+    const isSelfClosing = token.trimEnd().endsWith("/>");
+    const xmlUrl = getAttribute(token, "xmlUrl");
+    const text = getAttribute(token, "text") ?? getAttribute(token, "title") ?? "";
+
+    if (xmlUrl) {
+      const category = categoryStack[categoryStack.length - 1] ?? "";
+      results.push({ url: xmlUrl, title: text, category });
+      // Feed outlines with xmlUrl are treated as leaves even if not self-closing
+    } else if (!isSelfClosing) {
+      // Category outline: opening tag without xmlUrl — push to stack
+      categoryStack.push(text);
+    }
+    // Self-closing without xmlUrl: silently skip
+  }
+
+  return results;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export async function importOpml(db: Database.Database, filePath: string): Promise<ImportResult> {
+  let xml: string;
+
+  try {
+    xml = await readFile(filePath, "utf-8");
+  } catch (err) {
+    throw new Error(
+      `Failed to read OPML file "${filePath}": ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!/<opml\b/i.test(xml)) {
+    throw new Error(
+      `File "${filePath}" does not appear to be a valid OPML document (missing <opml> tag).`,
+    );
+  }
+
+  const feeds = parseOpmlFeeds(xml);
+
+  const result: ImportResult = { added: 0, skipped: 0, errors: [] };
+
+  for (const feed of feeds) {
+    try {
+      const existing = getFeedByUrl(db, feed.url);
+      if (existing) {
+        result.skipped++;
+      } else {
+        addFeed(db, {
+          url: feed.url,
+          title: feed.title,
+          description: "",
+          site_url: "",
+          category: feed.category,
+        });
+        result.added++;
+      }
+    } catch (err) {
+      result.errors.push(
+        `Error importing feed "${feed.url}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
Closes #5

## Summary

Implements the OPML import service for the Burp CLI RSS reader.

### What's added

- **`src/services/opml.ts`** — `importOpml(db, filePath)` function that:
  - Reads an OPML file and validates it has an `<opml>` tag
  - Parses `<outline>` elements using regex/string operations (no external XML parser)
  - Supports flat feeds and category-nested feeds (parent `<outline>` without `xmlUrl` sets the category)
  - Checks `getFeedByUrl` before inserting to track added vs skipped counts
  - Catches per-feed errors and continues processing
  - Throws clear errors for unreadable or non-OPML files

- **`src/services/opml.test.ts`** — 6 Vitest tests covering:
  1. Flat OPML adds all feeds
  2. Categorized OPML assigns correct categories
  3. Re-import increments skipped count
  4. Non-existent file throws clear error
  5. Non-OPML file throws clear error
  6. Outline missing `xmlUrl` is silently skipped