### PR TITLE
feat: RSS feed fetch and parse service

### DIFF
--- a/src/services/feed.test.ts
+++ b/src/services/feed.test.ts
@@ -1,0 +1,156 @@
+import Database from "better-sqlite3";
+import Parser from "rss-parser";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { addFeed, listArticlesByFeed } from "../db/queries";
+import { runMigrations } from "../db/schema";
+import * as feedService from "./feed";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+});
+
+afterEach(() => {
+  db.close();
+  vi.restoreAllMocks();
+});
+
+const MOCK_PARSED_FEED: feedService.ParsedFeed = {
+  title: "Test Feed",
+  description: "A feed for testing",
+  site_url: "https://example.com",
+  items: [
+    {
+      guid: "guid-1",
+      title: "Article One",
+      link: "https://example.com/1",
+      content: "Full content one",
+      summary: "Summary one",
+      author: "Alice",
+      published_at: 1700000000,
+    },
+    {
+      guid: "guid-2",
+      title: "Article Two",
+      link: "https://example.com/2",
+      content: "Full content two",
+      summary: "Summary two",
+      author: "Bob",
+      published_at: 1700000100,
+    },
+  ],
+};
+
+function mockParseURL(feed: feedService.ParsedFeed) {
+  vi.spyOn(Parser.prototype, "parseURL").mockResolvedValue({
+    title: feed.title,
+    description: feed.description,
+    link: feed.site_url,
+    items: feed.items.map((item) => ({
+      guid: item.guid,
+      title: item.title,
+      link: item.link,
+      content: item.content,
+      contentSnippet: item.summary,
+      creator: item.author,
+      pubDate: item.published_at ? new Date(item.published_at * 1000).toUTCString() : undefined,
+    })),
+  } as never);
+}
+
+describe("refreshFeed", () => {
+  it("inserts articles from a parsed feed into the DB", async () => {
+    mockParseURL(MOCK_PARSED_FEED);
+
+    const dbFeed = addFeed(db, {
+      url: "https://example.com/feed",
+      title: "Test Feed",
+      description: "",
+      site_url: "",
+      category: "",
+    });
+
+    const result = await feedService.refreshFeed(db, dbFeed.id);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.added).toBe(2);
+
+    const articles = listArticlesByFeed(db, dbFeed.id);
+    expect(articles).toHaveLength(2);
+    expect(articles.map((a) => a.guid)).toContain("guid-1");
+  });
+
+  it("does not create duplicates when re-fetching the same feed", async () => {
+    mockParseURL(MOCK_PARSED_FEED);
+
+    const dbFeed = addFeed(db, {
+      url: "https://example.com/feed",
+      title: "Test Feed",
+      description: "",
+      site_url: "",
+      category: "",
+    });
+
+    await feedService.refreshFeed(db, dbFeed.id);
+    await feedService.refreshFeed(db, dbFeed.id);
+
+    const articles = listArticlesByFeed(db, dbFeed.id);
+    expect(articles).toHaveLength(2);
+  });
+
+  it("catches a parse/network error and returns it in errors, does not throw", async () => {
+    vi.spyOn(Parser.prototype, "parseURL").mockRejectedValue(new Error("Network timeout"));
+
+    const dbFeed = addFeed(db, {
+      url: "https://bad-url.example.com/feed",
+      title: "Bad Feed",
+      description: "",
+      site_url: "",
+      category: "",
+    });
+
+    const result = await feedService.refreshFeed(db, dbFeed.id);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("Network timeout");
+    expect(result.added).toBe(0);
+  });
+
+  it("returns an error for an unknown feedId without throwing", async () => {
+    const result = await feedService.refreshFeed(db, 9999);
+    expect(result.errors).toHaveLength(1);
+    expect(result.added).toBe(0);
+  });
+});
+
+describe("refreshAllFeeds", () => {
+  it("processes all feeds and returns one result per feed", async () => {
+    mockParseURL(MOCK_PARSED_FEED);
+
+    addFeed(db, {
+      url: "https://a.com/feed",
+      title: "Feed A",
+      description: "",
+      site_url: "",
+      category: "",
+    });
+    addFeed(db, {
+      url: "https://b.com/feed",
+      title: "Feed B",
+      description: "",
+      site_url: "",
+      category: "",
+    });
+
+    const results = await feedService.refreshAllFeeds(db);
+
+    expect(results).toHaveLength(2);
+    for (const r of results) {
+      expect(r.added).toBe(2);
+      expect(r.errors).toHaveLength(0);
+    }
+  });
+});

--- a/src/services/feed.ts
+++ b/src/services/feed.ts
@@ -1,0 +1,105 @@
+import type Database from "better-sqlite3";
+import Parser from "rss-parser";
+import type { UpsertArticleInput } from "../db/queries";
+import { getFeedById, listFeeds, touchFeedFetchedAt, upsertArticle } from "../db/queries";
+
+export interface ParsedFeedItem {
+  guid: string;
+  title: string;
+  link: string;
+  content: string;
+  summary: string;
+  author: string;
+  published_at: number | null;
+}
+
+export interface ParsedFeed {
+  title: string;
+  description: string;
+  site_url: string;
+  items: ParsedFeedItem[];
+}
+
+export interface RefreshResult {
+  feedId: number;
+  added: number;
+  errors: string[];
+}
+
+const parser = new Parser({
+  customFields: {
+    item: [["content:encoded", "content:encoded"]],
+  },
+});
+
+function toUnixSeconds(dateStr: string | undefined): number | null {
+  if (!dateStr) return null;
+  const ms = Date.parse(dateStr);
+  return Number.isNaN(ms) ? null : Math.floor(ms / 1000);
+}
+
+export async function fetchAndParseFeed(url: string): Promise<ParsedFeed> {
+  const feed = await parser.parseURL(url);
+
+  const items: ParsedFeedItem[] = (feed.items ?? []).map((item) => ({
+    guid: item.guid ?? item.link ?? item.title ?? "",
+    title: item.title ?? "",
+    link: item.link ?? "",
+    content: (item as Record<string, string>)["content:encoded"] ?? item.content ?? "",
+    summary: item.contentSnippet ?? "",
+    author: item.creator ?? item.author ?? "",
+    published_at: toUnixSeconds(item.pubDate ?? item.isoDate),
+  }));
+
+  return {
+    title: feed.title ?? "",
+    description: feed.description ?? "",
+    site_url: feed.link ?? "",
+    items,
+  };
+}
+
+export async function refreshFeed(db: Database.Database, feedId: number): Promise<RefreshResult> {
+  const result: RefreshResult = { feedId, added: 0, errors: [] };
+
+  const feed = getFeedById(db, feedId);
+  if (!feed) {
+    result.errors.push(`Feed ${feedId} not found`);
+    return result;
+  }
+
+  let parsed: ParsedFeed;
+  try {
+    parsed = await fetchAndParseFeed(feed.url);
+  } catch (err) {
+    result.errors.push(err instanceof Error ? err.message : String(err));
+    return result;
+  }
+
+  for (const item of parsed.items) {
+    try {
+      const input: UpsertArticleInput = {
+        feed_id: feedId,
+        guid: item.guid,
+        title: item.title,
+        link: item.link,
+        content: item.content,
+        summary: item.summary,
+        author: item.author,
+        published_at: item.published_at,
+      };
+      upsertArticle(db, input);
+      result.added++;
+    } catch (err) {
+      result.errors.push(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  touchFeedFetchedAt(db, feedId);
+  return result;
+}
+
+export async function refreshAllFeeds(db: Database.Database): Promise<RefreshResult[]> {
+  const feeds = listFeeds(db);
+  return Promise.all(feeds.map((f) => refreshFeed(db, f.id)));
+}


### PR DESCRIPTION
Closes #4

## Changes
- `src/services/feed.ts`
  - `fetchAndParseFeed(url)` — fetches and parses via `rss-parser`, returns typed `ParsedFeed`
  - `refreshFeed(db, feedId)` — upserts articles, calls `touchFeedFetchedAt`, catches errors gracefully
  - `refreshAllFeeds(db)` — runs all feeds in parallel
  - Field mapping: guid, content, summary, author, published_at from rss-parser item
- `src/services/feed.test.ts` — 5 Vitest tests mocking `Parser.prototype.parseURL`

## Verification
- `bun run test` ✅ (37 tests passing)
- `bun run lint` ✅