### PR TITLE
feat: TUI shell, routing, navigation and views

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,0 +1,359 @@
+import { exec } from "node:child_process";
+import { platform } from "node:os";
+import type Database from "better-sqlite3";
+import { convert } from "html-to-text";
+import { Box, useApp, useInput } from "ink";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { StatusBar } from "./components/StatusBar";
+import type { Article, Feed, FeedWithUnread } from "./db/queries";
+import {
+  getFeedById,
+  listAllArticles,
+  listArticlesByFeed,
+  listFeeds,
+  markAllArticlesRead,
+  markArticleRead,
+  removeFeed,
+  toggleArticleStarred,
+} from "./db/queries";
+import { addFeed as addFeedToDb } from "./db/queries";
+import { fetchAndParseFeed, refreshAllFeeds, refreshFeed } from "./services/feed";
+import { importOpml } from "./services/opml";
+import { searchArticles } from "./services/search";
+import type { SearchResult } from "./services/search";
+import { AddFeed } from "./views/AddFeed";
+import { ArticleList } from "./views/ArticleList";
+import { ArticleView } from "./views/ArticleView";
+import { FeedList } from "./views/FeedList";
+import { Search } from "./views/Search";
+
+type View = "feedList" | "articleList" | "articleView" | "addFeed" | "search";
+
+interface AppProps {
+  db: Database.Database;
+  initialOpmlPath?: string;
+}
+
+function openInBrowser(url: string) {
+  const cmd = platform() === "darwin" ? `open "${url}"` : `xdg-open "${url}"`;
+  exec(cmd);
+}
+
+export function App({ db, initialOpmlPath }: AppProps) {
+  const { exit } = useApp();
+
+  // ── View state ──────────────────────────────────────────────────────────────
+  const [view, setView] = useState<View>("feedList");
+
+  // ── Feed list ────────────────────────────────────────────────────────────────
+  const [feeds, setFeeds] = useState<FeedWithUnread[]>([]);
+  const [feedIndex, setFeedIndex] = useState(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | undefined>();
+
+  // ── Article list ─────────────────────────────────────────────────────────────
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [articleIndex, setArticleIndex] = useState(0);
+  const [currentFeedTitle, setCurrentFeedTitle] = useState("All");
+
+  // ── Article view ─────────────────────────────────────────────────────────────
+  const [currentArticle, setCurrentArticle] = useState<Article | null>(null);
+  const [renderedContent, setRenderedContent] = useState("");
+  const [scrollOffset, setScrollOffset] = useState(0);
+
+  // ── Add feed ─────────────────────────────────────────────────────────────────
+  const [addFeedError, setAddFeedError] = useState<string | undefined>();
+
+  // ── Search ───────────────────────────────────────────────────────────────────
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [searchIndex, setSearchIndex] = useState(0);
+
+  const refreshTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // ── Helpers ──────────────────────────────────────────────────────────────────
+  const reloadFeeds = useCallback(() => {
+    setFeeds(listFeeds(db));
+  }, [db]);
+
+  const flash = useCallback((msg: string, ms = 2000) => {
+    setStatusMessage(msg);
+    if (refreshTimeout.current) clearTimeout(refreshTimeout.current);
+    refreshTimeout.current = setTimeout(() => setStatusMessage(undefined), ms);
+  }, []);
+
+  const doRefreshAll = useCallback(async () => {
+    setIsRefreshing(true);
+    await refreshAllFeeds(db);
+    reloadFeeds();
+    setIsRefreshing(false);
+    flash("Feeds refreshed");
+  }, [db, reloadFeeds, flash]);
+
+  // ── On mount: auto-refresh + optional OPML import ────────────────────────────
+  useEffect(() => {
+    reloadFeeds();
+    doRefreshAll();
+
+    if (initialOpmlPath) {
+      importOpml(db, initialOpmlPath)
+        .then((result) => {
+          flash(`OPML imported: ${result.added} added, ${result.skipped} skipped`);
+          reloadFeeds();
+        })
+        .catch((err: Error) => flash(`OPML error: ${err.message}`));
+    }
+  }, [db, reloadFeeds, doRefreshAll, flash, initialOpmlPath]);
+
+  // ── Search: update results on query change ───────────────────────────────────
+  useEffect(() => {
+    if (view !== "search") return;
+    const results = searchArticles(db, searchQuery);
+    setSearchResults(results);
+    setSearchIndex(0);
+  }, [searchQuery, view, db]);
+
+  // ── Input handling ───────────────────────────────────────────────────────────
+  useInput((input, key) => {
+    if (view === "addFeed" || view === "search") {
+      if (key.escape) {
+        setView("feedList");
+        setSearchQuery("");
+      }
+      return;
+    }
+
+    // Global navigation
+    if (key.escape || input === "q") {
+      if (view === "articleView") {
+        setView("articleList");
+      } else if (view === "articleList") {
+        setView("feedList");
+      } else {
+        exit();
+      }
+      return;
+    }
+
+    if (view === "feedList") {
+      if (input === "j" || key.downArrow) setFeedIndex((i) => Math.min(i + 1, feeds.length - 1));
+      else if (input === "k" || key.upArrow) setFeedIndex((i) => Math.max(i - 1, 0));
+      else if (key.return) openFeedArticles();
+      else if (input === "a") {
+        setAddFeedError(undefined);
+        setView("addFeed");
+      } else if (input === "d") deleteFeed();
+      else if (input === "r") doRefreshAll();
+      else if (input === "i") promptOpmlImport();
+      else if (input === "/") {
+        setSearchQuery("");
+        setView("search");
+      }
+    }
+
+    if (view === "articleList") {
+      if (input === "j" || key.downArrow)
+        setArticleIndex((i) => Math.min(i + 1, articles.length - 1));
+      else if (input === "k" || key.upArrow) setArticleIndex((i) => Math.max(i - 1, 0));
+      else if (key.return) openArticle();
+      else if (input === "s") toggleStar();
+      else if (input === "m") toggleRead();
+      else if (input === "r") refreshCurrentFeed();
+      else if (input === "/") {
+        setSearchQuery("");
+        setView("search");
+      }
+    }
+
+    if (view === "articleView") {
+      if (input === "j" || key.downArrow) setScrollOffset((s) => s + 1);
+      else if (input === "k" || key.upArrow) setScrollOffset((s) => Math.max(0, s - 1));
+      else if (input === "s" && currentArticle) toggleArticleStarred(db, currentArticle.id);
+      else if (input === "m" && currentArticle) {
+        markArticleRead(db, currentArticle.id, currentArticle.is_read !== 1);
+        reloadFeeds();
+      } else if (input === "o" && currentArticle?.link) openInBrowser(currentArticle.link);
+    }
+  });
+
+  // ── Feed list actions ─────────────────────────────────────────────────────────
+  function openFeedArticles() {
+    const feed = feeds[feedIndex];
+    if (!feed) return;
+    const arts = listArticlesByFeed(db, feed.id);
+    setArticles(arts);
+    setArticleIndex(0);
+    setCurrentFeedTitle(feed.title || feed.url);
+    setView("articleList");
+  }
+
+  function deleteFeed() {
+    const feed = feeds[feedIndex];
+    if (!feed) return;
+    removeFeed(db, feed.id);
+    reloadFeeds();
+    setFeedIndex((i) => Math.max(0, i - 1));
+    flash(`Removed "${feed.title || feed.url}"`);
+  }
+
+  function promptOpmlImport() {
+    flash("Pass --import <file.opml> on launch to import OPML");
+  }
+
+  // ── Article list actions ──────────────────────────────────────────────────────
+  function openArticle() {
+    const article = articles[articleIndex];
+    if (!article) return;
+    markArticleRead(db, article.id, true);
+    reloadFeeds();
+    const text = convert(article.content || article.summary, {
+      wordwrap: 80,
+      selectors: [
+        { selector: "a", options: { ignoreHref: true } },
+        { selector: "img", format: "skip" },
+      ],
+    });
+    setRenderedContent(text);
+    setScrollOffset(0);
+    setCurrentArticle(article);
+    setView("articleView");
+  }
+
+  function toggleStar() {
+    const article = articles[articleIndex];
+    if (!article) return;
+    toggleArticleStarred(db, article.id);
+    const feed = feeds[feedIndex];
+    if (feed) setArticles(listArticlesByFeed(db, feed.id));
+  }
+
+  function toggleRead() {
+    const article = articles[articleIndex];
+    if (!article) return;
+    markArticleRead(db, article.id, article.is_read !== 1);
+    reloadFeeds();
+    const feed = feeds[feedIndex];
+    if (feed) setArticles(listArticlesByFeed(db, feed.id));
+  }
+
+  async function refreshCurrentFeed() {
+    const feed = feeds[feedIndex];
+    if (!feed) return;
+    setIsRefreshing(true);
+    await refreshFeed(db, feed.id);
+    reloadFeeds();
+    setArticles(listArticlesByFeed(db, feed.id));
+    setIsRefreshing(false);
+    flash(`${feed.title} refreshed`);
+  }
+
+  // ── Add feed action ───────────────────────────────────────────────────────────
+  async function handleAddFeed(url: string, category: string) {
+    try {
+      const parsed = await fetchAndParseFeed(url);
+      addFeedToDb(db, {
+        url,
+        title: parsed.title,
+        description: parsed.description,
+        site_url: parsed.site_url,
+        category,
+      });
+      reloadFeeds();
+      setView("feedList");
+      flash(`Added "${parsed.title || url}"`);
+    } catch (err) {
+      setAddFeedError(err instanceof Error ? err.message : "Failed to fetch feed");
+    }
+  }
+
+  // ── Search action ─────────────────────────────────────────────────────────────
+  function handleSearchSelect(result: SearchResult) {
+    const feed = getFeedById(db, result.feed_id);
+    const arts = feed ? listArticlesByFeed(db, feed.id) : listAllArticles(db);
+    const idx = arts.findIndex((a) => a.id === result.id);
+    setArticles(arts);
+    setArticleIndex(idx >= 0 ? idx : 0);
+    setCurrentFeedTitle((feed as Feed | undefined)?.title || "All");
+    setView("articleList");
+  }
+
+  // ── Status bar hints per view ─────────────────────────────────────────────────
+  const hints: Record<View, { key: string; label: string }[]> = {
+    feedList: [
+      { key: "j/k", label: "navigate" },
+      { key: "↵", label: "open" },
+      { key: "a", label: "add" },
+      { key: "d", label: "delete" },
+      { key: "r", label: "refresh" },
+      { key: "/", label: "search" },
+      { key: "q", label: "quit" },
+    ],
+    articleList: [
+      { key: "j/k", label: "navigate" },
+      { key: "↵", label: "read" },
+      { key: "s", label: "star" },
+      { key: "m", label: "read/unread" },
+      { key: "r", label: "refresh" },
+      { key: "/", label: "search" },
+      { key: "Esc", label: "back" },
+    ],
+    articleView: [
+      { key: "j/k", label: "scroll" },
+      { key: "o", label: "browser" },
+      { key: "s", label: "star" },
+      { key: "m", label: "read/unread" },
+      { key: "Esc/q", label: "back" },
+    ],
+    addFeed: [
+      { key: "↵", label: "confirm" },
+      { key: "Esc", label: "cancel" },
+    ],
+    search: [
+      { key: "↵", label: "open" },
+      { key: "Esc", label: "back" },
+    ],
+  };
+
+  // ── Render ────────────────────────────────────────────────────────────────────
+  return (
+    <Box flexDirection="column" height={process.stdout.rows ?? 24}>
+      <Box flexGrow={1} flexDirection="column">
+        {view === "feedList" && (
+          <FeedList feeds={feeds} selectedIndex={feedIndex} isRefreshing={isRefreshing} />
+        )}
+        {view === "articleList" && (
+          <ArticleList
+            articles={articles}
+            selectedIndex={articleIndex}
+            feedTitle={currentFeedTitle}
+          />
+        )}
+        {view === "articleView" && currentArticle && (
+          <ArticleView
+            article={currentArticle}
+            feedTitle={currentFeedTitle}
+            renderedContent={renderedContent}
+            scrollOffset={scrollOffset}
+          />
+        )}
+        {view === "addFeed" && (
+          <AddFeed
+            onAdd={handleAddFeed}
+            onCancel={() => setView("feedList")}
+            error={addFeedError}
+          />
+        )}
+        {view === "search" && (
+          <Search
+            query={searchQuery}
+            onQueryChange={setSearchQuery}
+            results={searchResults}
+            selectedIndex={searchIndex}
+            onSelect={handleSearchSelect}
+          />
+        )}
+      </Box>
+      <StatusBar hints={hints[view]} message={statusMessage} />
+    </Box>
+  );
+}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,0 +1,40 @@
+import { Box, Text } from "ink";
+import React from "react";
+
+interface KeyHint {
+  key: string;
+  label: string;
+}
+
+interface StatusBarProps {
+  hints: KeyHint[];
+  message?: string;
+}
+
+export function StatusBar({ hints, message }: StatusBarProps) {
+  return (
+    <Box
+      borderStyle="single"
+      borderTop
+      borderBottom={false}
+      borderLeft={false}
+      borderRight={false}
+      paddingX={1}
+    >
+      {message ? (
+        <Text color="yellow">{message}</Text>
+      ) : (
+        <Box gap={2} flexWrap="wrap">
+          {hints.map(({ key, label }) => (
+            <Box key={key} gap={1}>
+              <Text bold color="cyan">
+                {key}
+              </Text>
+              <Text dimColor>{label}</Text>
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,0 +1,11 @@
+import { Text } from "ink";
+import React from "react";
+
+interface TagProps {
+  name: string;
+  color?: string;
+}
+
+export function Tag({ name, color = "magenta" }: TagProps) {
+  return <Text color={color}>[{name}]</Text>;
+}

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,0 +1,20 @@
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { runMigrations } from "./schema";
+
+const DB_DIR = join(homedir(), ".config", "burp");
+const DB_PATH = join(DB_DIR, "burp.db");
+
+let _db: Database.Database | null = null;
+
+export function getDb(): Database.Database {
+  if (_db) return _db;
+  mkdirSync(DB_DIR, { recursive: true });
+  _db = new Database(DB_PATH);
+  _db.pragma("journal_mode = WAL");
+  _db.pragma("foreign_keys = ON");
+  runMigrations(_db);
+  return _db;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,107 @@
-// Entry point — CLI arg parsing and app bootstrap (implemented in issue #7/#10)
 import { render } from "ink";
 import React from "react";
+import { App } from "./app";
+import { getDb } from "./db/connection";
+import { addFeed, listFeeds, markAllArticlesRead } from "./db/queries";
+import { fetchAndParseFeed, refreshAllFeeds } from "./services/feed";
+import { importOpml } from "./services/opml";
 
-function App() {
-  return <></>;
+const args = process.argv.slice(2);
+const command = args[0];
+
+async function runCli() {
+  const db = getDb();
+
+  // ── Non-interactive commands ──────────────────────────────────────────────
+  if (command === "add") {
+    const url = args[1];
+    const categoryIdx = args.indexOf("--category");
+    const category = categoryIdx !== -1 ? (args[categoryIdx + 1] ?? "") : "";
+
+    if (!url) {
+      console.error("Usage: burp add <url> [--category <name>]");
+      process.exit(1);
+    }
+    try {
+      const parsed = await fetchAndParseFeed(url);
+      addFeed(db, {
+        url,
+        title: parsed.title,
+        description: parsed.description,
+        site_url: parsed.site_url,
+        category,
+      });
+      console.log(`Added: ${parsed.title || url}`);
+    } catch (err) {
+      console.error(`Error: ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (command === "import") {
+    const filePath = args[1];
+    if (!filePath) {
+      console.error("Usage: burp import <file.opml>");
+      process.exit(1);
+    }
+    try {
+      const result = await importOpml(db, filePath);
+      console.log(`Imported: ${result.added} added, ${result.skipped} skipped`);
+      if (result.errors.length > 0) {
+        for (const e of result.errors) console.warn(`  Warning: ${e}`);
+      }
+    } catch (err) {
+      console.error(`Error: ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (command === "refresh") {
+    const results = await refreshAllFeeds(db);
+    const total = results.reduce((n, r) => n + r.added, 0);
+    console.log(`Refreshed ${results.length} feeds, ${total} new articles`);
+    return;
+  }
+
+  if (command === "list") {
+    const feeds = listFeeds(db);
+    if (feeds.length === 0) {
+      console.log("No feeds. Use: burp add <url>");
+      return;
+    }
+    for (const feed of feeds) {
+      const unread = feed.unread_count > 0 ? ` (${feed.unread_count} unread)` : "";
+      console.log(`${feed.title || feed.url}${unread}`);
+    }
+    return;
+  }
+
+  if (command === "mark-read") {
+    const feedId = Number(args[1]);
+    if (feedId) {
+      markAllArticlesRead(db, feedId);
+      console.log(`Marked all articles in feed ${feedId} as read`);
+    } else {
+      console.error("Usage: burp mark-read <feedId>");
+      process.exit(1);
+    }
+    return;
+  }
+
+  // ── Interactive TUI ───────────────────────────────────────────────────────
+  const importIdx = args.indexOf("--import");
+  const initialOpmlPath = importIdx !== -1 ? args[importIdx + 1] : undefined;
+
+  const { waitUntilExit } = render(<App db={db} initialOpmlPath={initialOpmlPath} />, {
+    exitOnCtrlC: true,
+  });
+
+  await waitUntilExit();
 }
 
-render(<App />);
+runCli().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/views/AddFeed.tsx
+++ b/src/views/AddFeed.tsx
@@ -1,0 +1,59 @@
+import { Box, Text } from "ink";
+import TextInput from "ink-text-input";
+import React, { useState } from "react";
+
+interface AddFeedProps {
+  onAdd: (url: string, category: string) => void;
+  onCancel: () => void;
+  error?: string;
+}
+
+export function AddFeed({ onAdd, onCancel, error }: AddFeedProps) {
+  const [url, setUrl] = useState("");
+  const [category, setCategory] = useState("");
+  const [focusedField, setFocusedField] = useState<"url" | "category">("url");
+
+  function handleUrlSubmit() {
+    setFocusedField("category");
+  }
+
+  function handleCategorySubmit() {
+    const trimmed = url.trim();
+    if (!trimmed) return;
+    onAdd(trimmed, category.trim());
+  }
+
+  return (
+    <Box flexDirection="column" flexGrow={1} padding={2} gap={1}>
+      <Text bold>Add Feed</Text>
+
+      <Box gap={1}>
+        <Text color={focusedField === "url" ? "cyan" : "white"}>URL:</Text>
+        <TextInput
+          value={url}
+          onChange={setUrl}
+          onSubmit={handleUrlSubmit}
+          focus={focusedField === "url"}
+          placeholder="https://example.com/feed.xml"
+        />
+      </Box>
+
+      <Box gap={1}>
+        <Text color={focusedField === "category" ? "cyan" : "white"}>Category:</Text>
+        <TextInput
+          value={category}
+          onChange={setCategory}
+          onSubmit={handleCategorySubmit}
+          focus={focusedField === "category"}
+          placeholder="(optional)"
+        />
+      </Box>
+
+      {error ? <Text color="red">{error}</Text> : null}
+
+      <Box marginTop={1}>
+        <Text dimColor>Enter to confirm each field • Esc to cancel</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/views/ArticleList.tsx
+++ b/src/views/ArticleList.tsx
@@ -1,0 +1,56 @@
+import { Box, Text } from "ink";
+import React from "react";
+import type { Article } from "../db/queries";
+
+interface ArticleListProps {
+  articles: Article[];
+  selectedIndex: number;
+  feedTitle: string;
+}
+
+function formatDate(unixSeconds: number | null): string {
+  if (!unixSeconds) return "—";
+  return new Date(unixSeconds * 1000).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function ArticleList({ articles, selectedIndex, feedTitle }: ArticleListProps) {
+  if (articles.length === 0) {
+    return (
+      <Box flexGrow={1} alignItems="center" justifyContent="center">
+        <Text dimColor>No articles in {feedTitle}.</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      <Box paddingX={1} marginBottom={1}>
+        <Text bold color="cyan">
+          {feedTitle}
+        </Text>
+      </Box>
+      {articles.map((article, i) => {
+        const isSelected = i === selectedIndex;
+        return (
+          <Box key={article.id} paddingX={1} gap={1}>
+            <Text
+              color={isSelected ? "cyan" : article.is_read ? undefined : "white"}
+              bold={!article.is_read}
+              inverse={isSelected}
+            >
+              {isSelected ? "▶ " : "  "}
+              {article.is_starred ? "★ " : "  "}
+              {article.is_read ? "" : "● "}
+              {article.title || "(no title)"}
+              <Text dimColor> {formatDate(article.published_at)}</Text>
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/views/ArticleView.tsx
+++ b/src/views/ArticleView.tsx
@@ -1,0 +1,52 @@
+import { Box, Text } from "ink";
+import React from "react";
+import type { Article } from "../db/queries";
+
+interface ArticleViewProps {
+  article: Article;
+  feedTitle: string;
+  renderedContent: string;
+  scrollOffset: number;
+}
+
+function formatDate(unixSeconds: number | null): string {
+  if (!unixSeconds) return "";
+  return new Date(unixSeconds * 1000).toLocaleDateString(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function ArticleView({
+  article,
+  feedTitle,
+  renderedContent,
+  scrollOffset,
+}: ArticleViewProps) {
+  const lines = renderedContent.split("\n");
+  const visible = lines.slice(scrollOffset, scrollOffset + 40);
+
+  return (
+    <Box flexDirection="column" flexGrow={1} paddingX={2}>
+      <Box flexDirection="column" marginBottom={1}>
+        <Text bold wrap="wrap">
+          {article.title}
+        </Text>
+        <Box gap={2}>
+          <Text dimColor>{feedTitle}</Text>
+          {article.author ? <Text dimColor>by {article.author}</Text> : null}
+          <Text dimColor>{formatDate(article.published_at)}</Text>
+        </Box>
+      </Box>
+      <Box flexDirection="column" flexGrow={1}>
+        {visible.map((line, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable scroll lines
+          <Text key={i} wrap="wrap">
+            {line}
+          </Text>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/views/FeedList.tsx
+++ b/src/views/FeedList.tsx
@@ -1,0 +1,47 @@
+import { Box, Text } from "ink";
+import React from "react";
+import type { FeedWithUnread } from "../db/queries";
+
+interface FeedListProps {
+  feeds: FeedWithUnread[];
+  selectedIndex: number;
+  isRefreshing: boolean;
+}
+
+export function FeedList({ feeds, selectedIndex, isRefreshing }: FeedListProps) {
+  if (isRefreshing) {
+    return (
+      <Box flexGrow={1} alignItems="center" justifyContent="center">
+        <Text color="cyan">Refreshing feeds…</Text>
+      </Box>
+    );
+  }
+
+  if (feeds.length === 0) {
+    return (
+      <Box flexGrow={1} alignItems="center" justifyContent="center">
+        <Text dimColor>No feeds yet. Press </Text>
+        <Text color="cyan">a</Text>
+        <Text dimColor> to add one.</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      {feeds.map((feed, i) => {
+        const isSelected = i === selectedIndex;
+        return (
+          <Box key={feed.id} paddingX={1}>
+            <Text color={isSelected ? "cyan" : undefined} bold={isSelected} inverse={isSelected}>
+              {isSelected ? "▶ " : "  "}
+              {feed.title || feed.url}
+              {feed.category ? <Text dimColor> [{feed.category}]</Text> : null}
+              {feed.unread_count > 0 ? <Text color="yellow"> ({feed.unread_count})</Text> : null}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/views/Search.tsx
+++ b/src/views/Search.tsx
@@ -1,0 +1,50 @@
+import { Box, Text } from "ink";
+import TextInput from "ink-text-input";
+import React from "react";
+import type { SearchResult } from "../services/search";
+
+interface SearchProps {
+  query: string;
+  onQueryChange: (q: string) => void;
+  results: SearchResult[];
+  selectedIndex: number;
+  onSelect: (result: SearchResult) => void;
+}
+
+export function Search({ query, onQueryChange, results, selectedIndex }: SearchProps) {
+  return (
+    <Box flexDirection="column" flexGrow={1} padding={1} gap={1}>
+      <Box gap={1}>
+        <Text color="cyan" bold>
+          Search:
+        </Text>
+        <TextInput value={query} onChange={onQueryChange} placeholder="Type to search…" />
+      </Box>
+
+      {results.length === 0 && query.trim() ? (
+        <Box paddingX={1}>
+          <Text dimColor>No results for "{query}"</Text>
+        </Box>
+      ) : (
+        <Box flexDirection="column" flexGrow={1}>
+          {results.map((result, i) => {
+            const isSelected = i === selectedIndex;
+            return (
+              <Box key={result.id} paddingX={1}>
+                <Text
+                  color={isSelected ? "cyan" : undefined}
+                  bold={isSelected}
+                  inverse={isSelected}
+                >
+                  {isSelected ? "▶ " : "  "}
+                  {result.title || "(no title)"}
+                  <Text dimColor> {result.feed_title}</Text>
+                </Text>
+              </Box>
+            );
+          })}
+        </Box>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
Closes #7

## Changes

### Core
- `src/db/connection.ts` — singleton DB, WAL mode, stored in `~/.config/burp/burp.db`
- `src/app.tsx` — Ink root with view router, global keyboard handler, auto-refresh on launch
- `src/index.tsx` — full CLI entry point with non-interactive commands (`burp add/import/refresh/list`)

### Views
- `FeedList.tsx` — feed list with unread counts, selection indicator
- `ArticleList.tsx` — articles sorted by date, read/starred status indicators
- `ArticleView.tsx` — scrollable full-content reading view (html-to-text rendering), open in browser with `o`
- `AddFeed.tsx` — two-field form (URL + optional category) via ink-text-input
- `Search.tsx` — live search results as user types

### Components
- `StatusBar.tsx` — context-aware keybinding hints at bottom of screen
- `Tag.tsx` — category/tag badge

## Verification
- `bun run test` ✅ (49 tests passing)
- `bun run lint` ✅
- `bun run build` ✅ (31.75 KB bundle)