### PR TITLE
ci: add Factory Droid Action for automatic PR reviews

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -1,0 +1,32 @@
+name: Droid Auto Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  droid-review:
+    if: |
+      github.event.pull_request.draft == false &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: Factory-AI/droid-action@v3
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          automatic_review: true

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -1,0 +1,41 @@
+name: Droid Tag
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  droid:
+    if: |
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@droid') &&
+         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@droid') &&
+         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@droid') &&
+         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'pull_request' && (contains(github.event.pull_request.body, '@droid') || contains(github.event.pull_request.title, '@droid')) &&
+         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: Factory-AI/droid-action@v3
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}


### PR DESCRIPTION
Closes #25
## Summary
Integrates the [Factory Droid Action](https://github.com/Factory-AI/droid-action) (v3) into the CI pipeline with two new GitHub Actions workflows: one for on-demand `@droid` commands and one for automatic code reviews on pull requests.
## Changes
- **`.github/workflows/droid.yml`** — Listens for `@droid` mentions in issue comments, PR review comments, PR reviews, and PR body/title. Triggers the Droid Action so collaborators can invoke commands like `@droid review`, ``, and `@droid security`. Permissions are read-only for contents and write for pull-requests/issues.
- **`.github/workflows/droid-review.yml`** — Automatically runs a Droid code review on every non-draft pull request when it is opened, marked ready for review, or reopened. Uses `automatic_review: true` and includes a concurrency group (`workflow + PR number`) to cancel in-progress runs when a new event arrives. Permissions include write access to contents and pull-requests.
## Implementation Details
- **Security gate:** Both workflows restrict execution to repository collaborators only (`OWNER`, `MEMBER`, `COLLABORATOR`) via `author_association` checks in the job-level `if` conditions. Comments or PRs from external contributors will not trigger any workflow runs.
- **Concurrency:** The auto-review workflow uses `cancel-in-progress: true` to avoid redundant review runs on rapid PR updates.
- **Permissions:** The tag workflow requests `contents: read`; the auto-review workflow requests `contents: write` (needed for Droid to push suggestions). Both request `id-token: write` for OIDC authentication.
## Testing
These are CI-only workflow files with no application code changes. Verification:
- Workflow YAML syntax is valid.
- Trigger events and conditions match the intended use cases.
- No existing workflows or application behaviour is affected.
## Requirements
Add a `FACTORY_API_KEY` repository secret (generate one at https://app.factory.ai/settings/api-keys) for the workflows to authenticate with the Factory API.
## Related Issues
- Closes #25