### PR TITLE
feat: add ASCII art header with double-line border and screen padding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,11 +29,13 @@ Always run `bun run test` and `bun run lint` before opening a PR. Fix all errors
 
 ## Workflow
 
-1. **Issue first** — Before starting any work, ensure a GitHub issue exists. If one was not specified by the user, create one with `gh issue create` describing the work.
-2. **Branch from main** — Create a branch named `issue/<number>-<short-slug>` off the latest `main`.
+> **Every step below is mandatory for every task — no exceptions, no skipping.**
+
+1. **Issue first (REQUIRED before any code)** — Before writing a single line of code, ensure a GitHub issue exists. If the user did not specify one, create it immediately with `gh issue create --project "Burp - CLI RSS Reader"`. Record the issue number — every subsequent step depends on it.
+2. **Branch from main (REQUIRED)** — Create a branch named `issue/<number>-<short-slug>` off the latest `main`. Never commit work directly to `main`.
 3. **Do the work** — Implement, test, and lint on the branch.
 4. **Update docs if needed** — Before opening a PR, check whether `AGENTS.md` or `README.md` need to reflect your changes (new commands, architecture changes, changed tooling, new conventions, etc.). Update them in the same PR.
-5. **Open a PR** — Every PR must:
+5. **Open a PR (REQUIRED after all work is done)** — Always open a PR when the task is complete — never leave finished work without one. Every PR must:
    - Follow Conventional Commits in the title (e.g. `feat:`, `fix:`, `ci:`) — CI enforces this.
    - Reference the closing issue in the body (`Closes #N`).
    - Be linked to the **Burp - CLI RSS Reader** GitHub project (`--project "Burp - CLI RSS Reader"`).

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,6 +4,7 @@ import { platform } from "node:os";
 import { convert } from "html-to-text";
 import { Box, useApp, useInput } from "ink";
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Header } from "./components/Header";
 import { StatusBar } from "./components/StatusBar";
 import type { Article, Feed, FeedWithUnread } from "./db/queries";
 import {
@@ -316,7 +317,8 @@ export function App({ db, initialOpmlPath }: AppProps) {
 
   // ── Render ────────────────────────────────────────────────────────────────────
   return (
-    <Box flexDirection="column" height={process.stdout.rows ?? 24}>
+    <Box flexDirection="column" height={process.stdout.rows ?? 24} paddingX={2} paddingTop={1}>
+      <Header />
       <Box flexGrow={1} flexDirection="column">
         {view === "feedList" && (
           <FeedList feeds={feeds} selectedIndex={feedIndex} isRefreshing={isRefreshing} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,21 @@
+import { Box, Text } from "ink";
+import React from "react";
+
+const ASCII_ART = `
+  ██████╗ ██╗   ██╗██████╗ ██████╗ 
+  ██╔══██╗██║   ██║██╔══██╗██╔══██╗
+  ██████╔╝██║   ██║██████╔╝██████╔╝
+  ██╔══██╗██║   ██║██╔══██╗██╔═══╝ 
+  ██████╔╝╚██████╔╝██║  ██║██║     
+  ╚═════╝  ╚═════╝ ╚═╝  ╚═╝╚═╝    `.trimStart();
+
+export function Header() {
+  return (
+    <Box borderStyle="double" borderColor="cyan" flexDirection="column" paddingX={2} paddingY={1}>
+      <Text color="cyan" bold>
+        {ASCII_ART}
+      </Text>
+      <Text dimColor>A cheeky terminal RSS reader</Text>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a bold, graffiti-style "BURP" ASCII art header inside a cyan double-line border to the top of the TUI, and adds horizontal/vertical padding so content no longer runs flush to the terminal edges.

## Changes

- **New `src/components/Header.tsx`** — graffiti block-style ASCII art wrapped in `borderStyle="double"` cyan border with dimmed tagline
- **`src/app.tsx`** — outer `<Box>` now has `paddingX={2}` and `paddingTop={1}`; renders `<Header />` at the top
- **`AGENTS.md`** — strengthened workflow section to make issue-first and PR-last steps explicitly mandatory

Closes #29